### PR TITLE
Update Podspec.

### DIFF
--- a/SimpleButton.podspec
+++ b/SimpleButton.podspec
@@ -1,15 +1,15 @@
 Pod::Spec.new do |s|
   s.name                  = "SimpleButton"
-  s.version               = "4.0.1"
+  s.version               = "5.0.0"
   s.summary               = "Simple UIButton subclass with additional state change animations (e.g. backgroundColor)"
   s.description           = "Simple UIButton subclass with animated, state-aware attributes. Easy to subclass and configure!"
   s.homepage              = "https://github.com/aloco/SimpleButton"
   s.license               = { :type => "MIT", :file => "LICENSE" }
   s.author                = { "Andreas Tinoco Lobo" => "andreas@tinoco-lobo.at" }
   s.platform              = :ios
-  s.ios.deployment_target = "8.1"
-  s.source                = { :git => "https://github.com/aloco/SimpleButton.git", :tag => s.version }
+  s.ios.deployment_target = "12.0"
+  s.source                = { :git => "https://github.com/aloco/SimpleButton.git", :tag => '5.0' }
   s.requires_arc          = true
   s.source_files          = "SimpleButton/*.swift"
-  s.swift_version        = "4.0"
+  s.swift_version        = "5.0"
 end

--- a/SimpleButton.podspec
+++ b/SimpleButton.podspec
@@ -11,5 +11,5 @@ Pod::Spec.new do |s|
   s.source                = { :git => "https://github.com/aloco/SimpleButton.git", :tag => '5.0' }
   s.requires_arc          = true
   s.source_files          = "SimpleButton/*.swift"
-  s.swift_version        = "5.0"
+  s.swift_version         = "5.0"
 end


### PR DESCRIPTION
## Summary

The current Podspec is outdated, not reflecting the latest changes in the repository, such as the migration to Swift 5 and the version bump to 5.0.0.

With this pull request, the `.podspec` will be up to date.

## Linter

```bash
❯ pod spec lint --allow-warnings

 -> SimpleButton (5.0.0)
    - WARN  | source: The version should be included in the Git tag.
    - NOTE  | xcodebuild:  note: Using new build system
    - NOTE  | xcodebuild:  note: Building targets in parallel
    - NOTE  | xcodebuild:  note: Using codesigning identity override: -
    - NOTE  | xcodebuild:  note: Build preparation complete
    - NOTE  | [iOS] xcodebuild:  note: Planning build
    - NOTE  | [iOS] xcodebuild:  note: Analyzing workspace
    - NOTE  | [iOS] xcodebuild:  note: Constructing build description
    - NOTE  | [iOS] xcodebuild:  warning: Capabilities for Signing & Capabilities may not function correctly because its entitlements use a placeholder team ID. To resolve this, select a development team in the App editor. (in target 'App' from project 'App')
    - NOTE  | [iOS] xcodebuild:  warning: Skipping code signing because the target does not have an Info.plist file and one is not being generated automatically. (in target 'App' from project 'App')

Analyzed 1 podspec.

SimpleButton.podspec passed validation.
```

Closes: #28